### PR TITLE
Complete modular Streamlit UI with landing, per-turn, and overall analysis

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -23,8 +23,6 @@ def prepare_per_turn_dataframe(transcript: list[dict]) -> pd.DataFrame:
 
 def compute_summary_stats(transcript_data: list[dict]) -> dict:
     df  = prepare_per_turn_dataframe(transcript_data)
-    # print("hello\n\n")
-    print(df.head(5))
     
     # Speaker stats
     speakers = df['speaker'].unique().tolist()

--- a/app/parser.py
+++ b/app/parser.py
@@ -1,32 +1,30 @@
 import os
 
-def parse_transcript(file_path: str) -> list[dict]:
+def parse_transcript(transcript_str: str) -> list[dict]:
     """
-    Reads and parses a transcript file.
-    Returns a list of dictionaries with 'speaker' and 'utterance'.
+    Parses transcript text string into a structured list of dialogue turns.
+    Each turn is expected to start with 'Speaker X:'
     """
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Transcript file not found at: {file_path}")
-    
+    lines = transcript_str.strip().split('\n')
     parsed_turns = []
 
-    with open(file_path, "r", encoding="utf-8") as f:
-        for i, line in enumerate(f):
-            line = line.strip()
-            if not line:
-                continue  # skip blank lines
+    for i, line in enumerate(lines):
+        line = line.strip()
+        if not line:
+            continue
 
-            if ":" not in line:
-                raise ValueError(f"Malformed line (missing ':'): {line}")
-            
-            speaker, utterance = line.split(":", 1)
-            parsed_turns.append({
-                "turn": i + 1,
-                "speaker": speaker.strip(),
-                "utterance": utterance.strip()
-            })
+        if ':' not in line:
+            raise ValueError(f"Malformed line at index {i + 1}: {line}")
+
+        speaker, utterance = line.split(':', 1)
+        parsed_turns.append({
+            "turn": i + 1,
+            "speaker": speaker.strip(),
+            "utterance": utterance.strip()
+        })
 
     return parsed_turns
+
 
 def get_speakers(transcript: list[dict]) -> list[str]:
     """

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -32,9 +32,9 @@ def main():
     per_turn_df = prepare_per_turn_dataframe(parsed_data)
     summary_stats = compute_summary_stats(parsed_data)
 
-    col1, col2, col3, col4 = st.columns(4)
+    col11, col12, col13, col14 = st.columns(4)
 
-    with col1:
+    with col11:
         st.markdown(f"""<div style='{metric_card_style}'>
         <div>👥 Speakers Detected</div>
         <ul style='text-align:left;'>
@@ -42,19 +42,19 @@ def main():
         </ul>
         </div>""", unsafe_allow_html=True)
 
-    with col2:
+    with col12:
         st.markdown(f"""<div style='{metric_card_style}'>
         <div>📄 Total Turns</div>
         <div style='font-size:2rem;font-weight:bold'>{summary_stats['num_turns']}</div>
         </div>""", unsafe_allow_html=True)
 
-    with col3:
+    with col13:
         st.markdown(f"""<div style='{metric_card_style}'>
         <div>💬 Avg Filler Ratio</div>
         <div style='font-size:2rem;font-weight:bold'>{round(summary_stats['avg_filler_ratio'],2)*100}%</div>
         </div>""", unsafe_allow_html=True)
 
-    with col4:
+    with col14:
         st.markdown(f"""<div style='{metric_card_style}'>
         <div>📊 Avg Sentiment Polarity</div>
         <div style='font-size:2rem;font-weight:bold'>{summary_stats['avg_sentiment_polarity']}</div>
@@ -62,95 +62,88 @@ def main():
 
     st.divider()
 
-    col5, col6 = st.columns(2)
+    # st.markdown("### 📋 Annotated Transcript")
+    st.markdown(f"""<div style='{metric_card_style}'>
+                <div style='font-size:2rem;font-weight:bold'>📋 Annotated Transcript</div>""", unsafe_allow_html=True)
+    st.dataframe(per_turn_df)
 
-    with col5:
-        st.markdown(f"""<div style='{metric_card_style}'>
-                    <div style='font-size:2rem;font-weight:bold'>🎯 Sentiment Distribution</div>"""
-                    ,unsafe_allow_html=True)
-        sentiment_dist = summary_stats['sentiment_distribution']
-        sentiment_df = pd.DataFrame({"Sentiment": list(sentiment_dist.keys()), "Count": list(sentiment_dist.values())})
-        fig_sentiment = px.pie(sentiment_df, names="Sentiment", values="Count", hole=0.4)
-        st.plotly_chart(fig_sentiment, use_container_width=True, key="sentiment_main")
-        st.markdown("</div>", unsafe_allow_html=True)
-
-    with col6:
-        st.markdown(f"""<div style='{metric_card_style}'>
-                    <div style='font-size:2rem;font-weight:bold'>🔠 Top 5 Filler Words</div>"""
-                    ,unsafe_allow_html=True)
-        top_fillers = summary_stats['top_fillers']
-        filler_df = pd.DataFrame(top_fillers, columns=["Filler Word", "Count"])
-        chart_type = st.radio("View As:", ["Bar Chart", "Table"], horizontal=True, key="filler_view")
-
-        if chart_type == "Bar Chart":
-            fig_filler = px.bar(filler_df, x="Filler Word", y="Count", color="Filler Word")
-            st.plotly_chart(fig_filler, use_container_width=True)
-        else:
-            st.dataframe(filler_df.set_index("Filler Word"))
-
-        st.markdown("</div>", unsafe_allow_html=True)
+    st.divider()
 
     # Per-Turn Metrics Expander
     with st.expander("🔍 Per-Turn Metrics", expanded=False):
-        st.markdown("### 📋 Annotated Transcript")
-        st.dataframe(per_turn_df)
 
-        col7, col8 = st.columns(2)
-        with col7:
+        col21, col22, col23 = st.columns(3)
+        with col21:
             st.markdown(f"""<div style='{metric_card_style}'>
                         <div style='font-size:2rem;font-weight:bold'>📈 Sentiment Polarity Trend</div>""", unsafe_allow_html=True)
-            # st.markdown("#### 📈 Sentiment Polarity Trend")
-            st.line_chart(per_turn_df['polarity_score'])
+            st.line_chart(per_turn_df['polarity_score'], use_container_width=True, x_label="Turn Number", y_label="Sentiment Polarity")
             st.markdown("</div>", unsafe_allow_html=True)
 
-        with col8:
+        with col22:
             st.markdown(f"""<div style='{metric_card_style}'>
                         <div style='font-size:2rem;font-weight:bold'>📉 Filler Ratio per Turn</div>""", unsafe_allow_html=True)
-            # st.markdown("#### 📉 Filler Ratio per Turn")
-            st.bar_chart(per_turn_df['filler_ratio'])
+            st.bar_chart(per_turn_df['filler_ratio'], use_container_width=True, x_label="Turn Number", y_label="Filler Ratio")
             st.markdown("</div>", unsafe_allow_html=True)
-
-        col9, col10 = st.columns(2)
-        with col9:
+            
+        
+        with col23:
             st.markdown(f"""<div style='{metric_card_style}'>
-                        <div style='font-size:2rem;font-weight:bold'>🔁 Sentiment Overlaid by Turn</div>""", unsafe_allow_html=True)
-            # st.markdown("#### 🔁 Sentiment Overlaid by Turn")
-            fig = px.line(per_turn_df, x=per_turn_df.index + 1, y='polarity_score', color='speaker')
+                         <div style='font-size:2rem;font-weight:bold'>🔁 Sentiment Overlaid by Turn</div>""", unsafe_allow_html=True)
+            fig = px.line(per_turn_df, x=per_turn_df.index + 1, y='polarity_score', color='speaker', 
+                          labels={'x': 'Turn Number', 'polarity_score': 'Sentiment Polarity'})
+            fig.update_layout(xaxis_title='Turn Number', yaxis_title='Sentiment Polarity')
             st.plotly_chart(fig, use_container_width=True)
             st.markdown("</div>", unsafe_allow_html=True)
 
-        with col10:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                        <div style='font-size:2rem;font-weight:bold'>🔁 Filler Ratio by Speaker</div>""", unsafe_allow_html=True)
-            # st.markdown("#### 🔁 Filler Ratio by Speaker")
-            fig = px.bar(per_turn_df, x='speaker', y='filler_ratio', color='speaker', barmode='group')
-            st.plotly_chart(fig, use_container_width=True)
-            st.markdown("</div>", unsafe_allow_html=True)
 
-        # Overall Metrics
+    # Overall Metrics
     with st.expander("📊 Overall Metrics", expanded=False):
-        col11, col12 = st.columns(2)
-        with col11:
-            st.markdown("#### 🎯 Sentiment Class Distribution (Pie Chart)")
-            st.plotly_chart(fig_sentiment, use_container_width=True, key="sentiment_overall")
 
-        with col12:
-            st.markdown("#### 🎚️ Filler Ratio Gauge (Custom Display)")
-            filler_display = f"<div style='font-size:3rem;font-weight:bold;color:#00BFFF;'>{round(summary_stats['avg_filler_ratio']*100, 2)}%</div>"
-            st.markdown(filler_display, unsafe_allow_html=True)
-
-        st.markdown("#### 👤 Speaker-wise Summary Table")
+        # st.markdown("#### 👤 Speaker-wise Summary Table")
+        st.markdown(f"""<div style='{metric_card_style}'>
+                <div style='font-size:2rem;font-weight:bold'>👤 Speaker-wise Summary Table</div>""", unsafe_allow_html=True)
         speaker_summary = per_turn_df.groupby('speaker')[['filler_ratio', 'polarity_score']].mean().reset_index()
         speaker_summary.columns = ['Speaker', 'Avg Filler Ratio', 'Avg Sentiment Polarity']
         st.dataframe(speaker_summary.set_index('Speaker'))
 
-        st.markdown("#### ☁️ Word Cloud of All Utterances")
-        all_text = " ".join(per_turn_df['utterance'].tolist())
-        wordcloud = WordCloud(width=800, height=400, background_color='white').generate(all_text)
-        fig_wc, ax_wc = plt.subplots()
-        ax_wc.imshow(wordcloud, interpolation='bilinear')
-        ax_wc.axis("off")
-        st.pyplot(fig_wc)
+        col31, col32, col33 = st.columns(3)
+        with col31:
+            st.markdown(f"""<div style='{metric_card_style}'>
+                    <div style='font-size:2rem;font-weight:bold'>🎯 Sentiment Distribution</div>"""
+                    ,unsafe_allow_html=True)
+            sentiment_dist = summary_stats['sentiment_distribution']
+            sentiment_df = pd.DataFrame({"Sentiment": list(sentiment_dist.keys()), "Count": list(sentiment_dist.values())})
+            fig_sentiment = px.pie(sentiment_df, names="Sentiment", values="Count", hole=0.4)
+            st.plotly_chart(fig_sentiment, use_container_width=True, key="sentiment_main")
+            st.markdown("</div>", unsafe_allow_html=True)
+
+        with col32:
+            st.markdown(f"""<div style='{metric_card_style}'>
+                    <div style='font-size:2rem;font-weight:bold'>☁️ Word Cloud of All Utterances</div>"""
+                    ,unsafe_allow_html=True)
+            all_text = " ".join(per_turn_df['utterance'].tolist())
+            wordcloud = WordCloud(width=800, height=400, background_color='white').generate(all_text)
+            fig_wc, ax_wc = plt.subplots()
+            ax_wc.imshow(wordcloud, interpolation='bilinear')
+            ax_wc.axis("off")
+            st.pyplot(fig_wc)
+
+        with col33:
+            st.markdown(f"""<div style='{metric_card_style}'>
+                    <div style='font-size:2rem;font-weight:bold'>🔠 Top 5 Filler Words</div>"""
+                    ,unsafe_allow_html=True)
+            top_fillers = summary_stats['top_fillers']
+            filler_df = pd.DataFrame(top_fillers, columns=["Filler Word", "Count"])
+            chart_type = st.radio("View As:", ["Bar Chart", "Table"], horizontal=True, key="filler_view")
+
+            if chart_type == "Bar Chart":
+                fig_filler = px.bar(filler_df, x="Filler Word", y="Count", color="Filler Word")
+                st.plotly_chart(fig_filler, use_container_width=True)
+            else:
+                st.dataframe(filler_df.set_index("Filler Word"))
+
+            st.markdown("</div>", unsafe_allow_html=True)
+
 
 if __name__ == "__main__":
     main()

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -1,11 +1,11 @@
 import streamlit as st
-import pandas as pd
-import plotly.express as px
 from app.parser import parse_transcript
 from app.metrics import compute_summary_stats, prepare_per_turn_dataframe
-from ui.components import metric_card_style
-from wordcloud import WordCloud
-import matplotlib.pyplot as plt
+from ui.styles.card_styles import section_header_style
+from ui.sections.landing_summary import render_landing_summary
+from ui.sections.annotated_transcript import render_annotated_transcript
+from ui.sections.per_turn_metrics import render_per_turn_metrics
+from ui.sections.overall_metrics import render_overall_metrics
 
 # Set page config
 st.set_page_config(page_title="Dialogue Insights Dashboard", layout="wide")
@@ -19,130 +19,31 @@ def main():
     if not uploaded_file:
         st.markdown("""
         ## ⏳ Awaiting Transcript Upload
-        Please upload a `.txt` file from the sidebar to begin analysis.
+        Please upload a `.txt` file to analyze.
         """)
         st.stop()
 
     # Read and parse the transcript
     transcript_str = uploaded_file.read().decode("utf-8")
-    with open("data/temp/temp_transcript.txt", "w", encoding="utf-8") as f:
-        f.write(transcript_str)
 
-    parsed_data = parse_transcript("data/temp/temp_transcript.txt")
+    parsed_data = parse_transcript(transcript_str)
     per_turn_df = prepare_per_turn_dataframe(parsed_data)
     summary_stats = compute_summary_stats(parsed_data)
 
-    col11, col12, col13, col14 = st.columns(4)
+    # Render the dashboard components
+    render_landing_summary(summary_stats)
+    render_annotated_transcript(per_turn_df)
 
-    with col11:
-        st.markdown(f"""<div style='{metric_card_style}'>
-        <div>👥 Speakers Detected</div>
-        <ul style='text-align:left;'>
-        {''.join([f'<li>{spk}</li>' for spk in summary_stats['speakers']])}
-        </ul>
-        </div>""", unsafe_allow_html=True)
-
-    with col12:
-        st.markdown(f"""<div style='{metric_card_style}'>
-        <div>📄 Total Turns</div>
-        <div style='font-size:2rem;font-weight:bold'>{summary_stats['num_turns']}</div>
-        </div>""", unsafe_allow_html=True)
-
-    with col13:
-        st.markdown(f"""<div style='{metric_card_style}'>
-        <div>💬 Avg Filler Ratio</div>
-        <div style='font-size:2rem;font-weight:bold'>{round(summary_stats['avg_filler_ratio'],2)*100}%</div>
-        </div>""", unsafe_allow_html=True)
-
-    with col14:
-        st.markdown(f"""<div style='{metric_card_style}'>
-        <div>📊 Avg Sentiment Polarity</div>
-        <div style='font-size:2rem;font-weight:bold'>{summary_stats['avg_sentiment_polarity']}</div>
-        </div>""", unsafe_allow_html=True)
-
-    st.divider()
-
-    # st.markdown("### 📋 Annotated Transcript")
-    st.markdown(f"""<div style='{metric_card_style}'>
-                <div style='font-size:2rem;font-weight:bold'>📋 Annotated Transcript</div>""", unsafe_allow_html=True)
-    st.dataframe(per_turn_df)
-
-    st.divider()
+    # Section Header
+    st.markdown(f"""<div style='{section_header_style}'>📊 Metrics Overview</div>""", unsafe_allow_html=True)
 
     # Per-Turn Metrics Expander
     with st.expander("🔍 Per-Turn Metrics", expanded=False):
-
-        col21, col22, col23 = st.columns(3)
-        with col21:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                        <div style='font-size:2rem;font-weight:bold'>📈 Sentiment Polarity Trend</div>""", unsafe_allow_html=True)
-            st.line_chart(per_turn_df['polarity_score'], use_container_width=True, x_label="Turn Number", y_label="Sentiment Polarity")
-            st.markdown("</div>", unsafe_allow_html=True)
-
-        with col22:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                        <div style='font-size:2rem;font-weight:bold'>📉 Filler Ratio per Turn</div>""", unsafe_allow_html=True)
-            st.bar_chart(per_turn_df['filler_ratio'], use_container_width=True, x_label="Turn Number", y_label="Filler Ratio")
-            st.markdown("</div>", unsafe_allow_html=True)
-            
-        
-        with col23:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                         <div style='font-size:2rem;font-weight:bold'>🔁 Sentiment Overlaid by Turn</div>""", unsafe_allow_html=True)
-            fig = px.line(per_turn_df, x=per_turn_df.index + 1, y='polarity_score', color='speaker', 
-                          labels={'x': 'Turn Number', 'polarity_score': 'Sentiment Polarity'})
-            fig.update_layout(xaxis_title='Turn Number', yaxis_title='Sentiment Polarity')
-            st.plotly_chart(fig, use_container_width=True)
-            st.markdown("</div>", unsafe_allow_html=True)
-
+        render_per_turn_metrics(per_turn_df)
 
     # Overall Metrics
     with st.expander("📊 Overall Metrics", expanded=False):
-
-        # st.markdown("#### 👤 Speaker-wise Summary Table")
-        st.markdown(f"""<div style='{metric_card_style}'>
-                <div style='font-size:2rem;font-weight:bold'>👤 Speaker-wise Summary Table</div>""", unsafe_allow_html=True)
-        speaker_summary = per_turn_df.groupby('speaker')[['filler_ratio', 'polarity_score']].mean().reset_index()
-        speaker_summary.columns = ['Speaker', 'Avg Filler Ratio', 'Avg Sentiment Polarity']
-        st.dataframe(speaker_summary.set_index('Speaker'))
-
-        col31, col32, col33 = st.columns(3)
-        with col31:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                    <div style='font-size:2rem;font-weight:bold'>🎯 Sentiment Distribution</div>"""
-                    ,unsafe_allow_html=True)
-            sentiment_dist = summary_stats['sentiment_distribution']
-            sentiment_df = pd.DataFrame({"Sentiment": list(sentiment_dist.keys()), "Count": list(sentiment_dist.values())})
-            fig_sentiment = px.pie(sentiment_df, names="Sentiment", values="Count", hole=0.4)
-            st.plotly_chart(fig_sentiment, use_container_width=True, key="sentiment_main")
-            st.markdown("</div>", unsafe_allow_html=True)
-
-        with col32:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                    <div style='font-size:2rem;font-weight:bold'>☁️ Word Cloud of All Utterances</div>"""
-                    ,unsafe_allow_html=True)
-            all_text = " ".join(per_turn_df['utterance'].tolist())
-            wordcloud = WordCloud(width=800, height=400, background_color='white').generate(all_text)
-            fig_wc, ax_wc = plt.subplots()
-            ax_wc.imshow(wordcloud, interpolation='bilinear')
-            ax_wc.axis("off")
-            st.pyplot(fig_wc)
-
-        with col33:
-            st.markdown(f"""<div style='{metric_card_style}'>
-                    <div style='font-size:2rem;font-weight:bold'>🔠 Top 5 Filler Words</div>"""
-                    ,unsafe_allow_html=True)
-            top_fillers = summary_stats['top_fillers']
-            filler_df = pd.DataFrame(top_fillers, columns=["Filler Word", "Count"])
-            chart_type = st.radio("View As:", ["Bar Chart", "Table"], horizontal=True, key="filler_view")
-
-            if chart_type == "Bar Chart":
-                fig_filler = px.bar(filler_df, x="Filler Word", y="Count", color="Filler Word")
-                st.plotly_chart(fig_filler, use_container_width=True)
-            else:
-                st.dataframe(filler_df.set_index("Filler Word"))
-
-            st.markdown("</div>", unsafe_allow_html=True)
+        render_overall_metrics(per_turn_df, summary_stats)
 
 
 if __name__ == "__main__":

--- a/ui/sections/annotated_transcript.py
+++ b/ui/sections/annotated_transcript.py
@@ -1,0 +1,12 @@
+import streamlit as st
+from ui.styles.card_styles import metric_card_style
+
+def render_annotated_transcript(df):
+    # st.markdown(f"""<div style='{metric_card_style}'>
+    #             <div style='font-size:2rem;font-weight:bold'>📋 Annotated Transcript</div>""", unsafe_allow_html=True)
+    st.markdown(f"""<div style='{metric_card_style}'>
+    <div style='font-size:1.5rem;font-weight:bold'>📋 Annotated Transcript</div>
+    <hr style='border: 1px solid #ccc; margin: 0.5rem 0;' />
+    """, unsafe_allow_html=True)
+    st.dataframe(df)
+    # st.divider()

--- a/ui/sections/landing_summary.py
+++ b/ui/sections/landing_summary.py
@@ -1,0 +1,30 @@
+import streamlit as st
+from ui.styles.card_styles import metric_card_style
+
+def render_landing_summary(stats: dict):
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        st.markdown(f"""<div style='{metric_card_style}'>
+        <div>👥 Speakers Detected</div>
+        <ul style='text-align:left;'>{''.join([f'<li>{spk}</li>' for spk in stats['speakers']])}</ul>
+        </div>""", unsafe_allow_html=True)
+
+    with col2:
+        st.markdown(f"""<div style='{metric_card_style}'>
+        <div>📄 Total Turns</div>
+        <div style='font-size:2rem;font-weight:bold'>{stats['num_turns']}</div>
+        </div>""", unsafe_allow_html=True)
+
+    with col3:
+        st.markdown(f"""<div style='{metric_card_style}'>
+        <div>💬 Avg Filler Ratio</div>
+        <div style='font-size:2rem;font-weight:bold'>{round(stats['avg_filler_ratio'], 2) * 100}%</div>
+        </div>""", unsafe_allow_html=True)
+
+    with col4:
+        st.markdown(f"""<div style='{metric_card_style}'>
+        <div>📊 Avg Sentiment Polarity</div>
+        <div style='font-size:2rem;font-weight:bold'>{stats['avg_sentiment_polarity']}</div>
+        </div>""", unsafe_allow_html=True)
+
+    st.divider()

--- a/ui/sections/overall_metrics.py
+++ b/ui/sections/overall_metrics.py
@@ -1,0 +1,60 @@
+import streamlit as st
+import plotly.express as px
+import pandas as pd
+from wordcloud import WordCloud
+from ui.styles.card_styles import metric_card_style
+from matplotlib import pyplot as plt
+
+def render_overall_metrics(per_turn_df: pd.DataFrame, summary_stats: dict):
+    # st.markdown(f"""<div style='{metric_card_style}'>
+    #         <div style='font-size:1.5rem;font-weight:bold'>👤 Speaker-wise Summary Table</div>""", unsafe_allow_html=True)
+    
+    st.markdown(f"""<div style='{metric_card_style}'>
+    <div style='font-size:1.5rem;font-weight:bold'>👤 Speaker-wise Summary Table</div>
+    <hr style='border: 1px solid #ccc; margin: 0.5rem 0;' />
+    """, unsafe_allow_html=True)
+
+    # st.markdown(f"""<div style='{section_header_style}'>🔍 Per-Turn Metrics Summary</div>""", unsafe_allow_html=True)
+
+
+    speaker_summary = per_turn_df.groupby('speaker')[['filler_ratio', 'polarity_score']].mean().reset_index()
+    speaker_summary.columns = ['Speaker', 'Avg Filler Ratio', 'Avg Sentiment Polarity']
+    st.dataframe(speaker_summary.set_index('Speaker'))
+
+    col31, col32, col33 = st.columns(3)
+    with col31:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                <div style='font-size:1.5rem;font-weight:bold'>🎯 Sentiment Distribution</div>"""
+                ,unsafe_allow_html=True)
+        sentiment_dist = summary_stats['sentiment_distribution']
+        sentiment_df = pd.DataFrame({"Sentiment": list(sentiment_dist.keys()), "Count": list(sentiment_dist.values())})
+        fig_sentiment = px.pie(sentiment_df, names="Sentiment", values="Count", hole=0.4)
+        st.plotly_chart(fig_sentiment, use_container_width=True, key="sentiment_main")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    with col32:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                <div style='font-size:1.5rem;font-weight:bold'>☁️ Word Cloud of All Utterances</div>"""
+                ,unsafe_allow_html=True)
+        all_text = " ".join(per_turn_df['utterance'].tolist())
+        wordcloud = WordCloud(width=800, height=750, background_color='white').generate(all_text)
+        fig_wc, ax_wc = plt.subplots()
+        ax_wc.imshow(wordcloud, interpolation='bilinear')
+        ax_wc.axis("off")
+        st.pyplot(fig_wc)
+
+    with col33:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                <div style='font-size:1.5rem;font-weight:bold'>🔠 Top 5 Filler Words</div>"""
+                ,unsafe_allow_html=True)
+        top_fillers = summary_stats['top_fillers']
+        filler_df = pd.DataFrame(top_fillers, columns=["Filler Word", "Count"])
+        chart_type = st.radio("", ["Bar Chart", "Table"], horizontal=True, key="filler_view")
+
+        if chart_type == "Bar Chart":
+            fig_filler = px.bar(filler_df, x="Filler Word", y="Count", color="Filler Word")
+            st.plotly_chart(fig_filler, use_container_width=True)
+        else:
+            st.dataframe(filler_df.set_index("Filler Word"))
+
+        st.markdown("</div>", unsafe_allow_html=True)

--- a/ui/sections/per_turn_metrics.py
+++ b/ui/sections/per_turn_metrics.py
@@ -1,0 +1,28 @@
+import streamlit as st
+import plotly.express as px
+import pandas as pd
+from ui.styles.card_styles import metric_card_style
+
+def render_per_turn_metrics(per_turn_df: pd.DataFrame):
+    col21, col22, col23 = st.columns(3)
+    with col21:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                    <div style='font-size:1.5rem;font-weight:bold'>📈 Sentiment Polarity Trend</div>""", unsafe_allow_html=True)
+        st.line_chart(per_turn_df['polarity_score'], use_container_width=True, x_label="Turn Number", y_label="Sentiment Polarity")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    with col22:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                    <div style='font-size:1.5rem;font-weight:bold'>📉 Filler Ratio per Turn</div>""", unsafe_allow_html=True)
+        st.bar_chart(per_turn_df['filler_ratio'], use_container_width=True, x_label="Turn Number", y_label="Filler Ratio")
+        st.markdown("</div>", unsafe_allow_html=True)
+        
+    
+    with col23:
+        st.markdown(f"""<div style='{metric_card_style}'>
+                        <div style='font-size:1.5rem;font-weight:bold'>🔁 Sentiment Overlaid by Turn</div>""", unsafe_allow_html=True)
+        fig = px.line(per_turn_df, x=per_turn_df.index + 1, y='polarity_score', color='speaker', 
+                        labels={'x': 'Turn Number', 'polarity_score': 'Sentiment Polarity'})
+        fig.update_layout(xaxis_title='Turn Number', yaxis_title='Sentiment Polarity')
+        st.plotly_chart(fig, use_container_width=True)
+        st.markdown("</div>", unsafe_allow_html=True)

--- a/ui/styles/card_styles.py
+++ b/ui/styles/card_styles.py
@@ -8,3 +8,13 @@ metric_card_style = """
     font-size: 1.2rem;
     box-shadow: 2px 2px 10px rgba(0,0,0,0.2);
 """
+
+section_header_style = """
+    font-size: 1.7rem;
+    font-weight: 600;
+    padding: 0.5rem 0;
+    color: #333;
+    background-color: #f4f4f4;
+    border-left: 6px solid #1f77b4;
+    padding-left: 1rem;
+"""


### PR DESCRIPTION

dashboard.py - Main controller invoking section UIs
sections/landing_summary.py - Renders 4 summary cards
sections/annotated_transcript.py - Displays the full annotated dataframe
sections/per_turn_metrics.py - 3x visualizations of turn-level analysis
sections/overall_metrics.py - Overall speaker and transcript-level charts
parser.py - Now accepts string input via parse_transcript()
ui/components.py changed into ui/styles/card_styles.py
